### PR TITLE
cmake: FindSQLITE3.cmake and README updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.6.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 message( STATUS "cmake version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" )
 
@@ -7,9 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
 project(cdobs C CXX)
 
-#set(CMAKE_CXX_FLAGS "")
-
-find_package(SQLite3 REQUIRED)
+find_package(SQLITE3 REQUIRED)
 
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # cdobs
 Database object storage backend for Ceph
 
+### Dependencies
+Install the following packages on Fedora for SQLite3:
+```bash
+sudo dnf install sqlite-devel sqlite-tcl sqlite-jdbc
+```
+
 ### Build
 ```bash
 # clone the repo

--- a/cmake/modules/FindSQLITE3.cmake
+++ b/cmake/modules/FindSQLITE3.cmake
@@ -19,12 +19,13 @@
 FIND_PATH(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
 
 # Look for the library.
-FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite)
+FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite sqlite3)
 
 # Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE if all listed variables are TRUE.
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SQLITE3 DEFAULT_MSG SQLITE3_LIBRARY SQLITE3_INCLUDE_DIR)
-
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SQLITE3
+                                  REQUIRED_VARS SQLITE3_LIBRARY SQLITE3_INCLUDE_DIR
+                                  FAIL_MESSAGE "Could not find sqlite3.h and/or libsqlite3.so")
 # Copy the results to the output variables.
 IF(SQLITE3_FOUND)
 	SET(SQLITE3_LIBRARIES ${SQLITE3_LIBRARY})


### PR DESCRIPTION
FindSQLITE3.cmake now fails when sqlite.h and sqlite.so are not
found

Updated README.md with dependencies for Fedora